### PR TITLE
feat: add controlled table file imports

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -25,8 +25,9 @@
 
 ## AI 能用它做什么
 
-当前这组工具主要面向数据库发现和受控查询流程。你可以用它帮助 AI 助手先
-理解结构，再生成或改写 SQL。
+当前这组工具主要面向数据库发现、受控查询流程，以及一个边界很窄的本地文
+件导入入口。你可以用它帮助 AI 助手先理解结构，再生成 SQL 或把准备好的
+CSV/XLSX 文件导入到已有表。
 
 MySQL 在当前实现中支持 `explain_query`，但不支持
 `explain_query(..., analyze=True)`。
@@ -41,14 +42,16 @@ MySQL 在当前实现中支持 `explain_query`，但不支持
 | `run_select(connection_id, sql, limit?)` | 是 | 是 | 运行只读查询 |
 | `explain_query(connection_id, sql, analyze?)` | 是 | 是 | 查看查询计划 |
 | `get_table_sample(connection_id, table_name, schema?, database?, limit?)` | 是 | 是 | 获取小规模表样本 |
+| `import_table_file(connection_id, table_name, file_path, schema?, database?, sheet_name?)` | 是 | 是 | 导入本地 CSV/XLSX 文件 |
 
-这些工具适合用于列出命名空间、检查表定义、查看索引、采样记录，以及用
-`EXPLAIN` 分析只读查询。完整的请求和响应细节见 `docs/api-reference.md`。
+这些工具适合用于列出命名空间、检查表定义、查看索引、采样记录、用
+`EXPLAIN` 分析只读查询，以及导入准备好的本地文件。完整的请求和响应细节
+见 `docs/api-reference.md`。
 
 ## 边界如何被清晰限定
 
-当前产品边界刻意保持得比较清晰。现在只有 PostgreSQL 和 MySQL 已经可用，
-而且当前工具集完全是只读的。
+当前产品边界刻意保持得比较清晰。现在只有 PostgreSQL 和 MySQL 已经可用。
+查询工具仍然是只读的，唯一写入入口是受控的本地 CSV/XLSX 文件导入。
 
 服务通过以下几种方式明确这些边界。
 
@@ -59,6 +62,8 @@ MySQL 在当前实现中支持 `explain_query`，但不支持
 - 查询执行在到达数据库之前会先经过 `sqlglot` 校验。
 - 服务只接受 `SELECT` 和 `WITH ... SELECT`，拒绝注释和多语句输入，并为每次
   调用记录审计日志。
+- `import_table_file` 不接受原始 SQL，只插入表头能精确匹配目标表字段的文件
+  列。
 
 对 MySQL 而言，`explain_query(..., analyze=True)` 在当前实现中不可用。
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ without exposing raw connection strings or flattening engine-specific concepts.
 
 ## What AI can do with it
 
-The current tool set focuses on database discovery and controlled query
-workflows. You can use it to help an AI assistant understand structure before
-it generates or refines SQL.
+The current tool set focuses on database discovery, controlled query workflows,
+and one narrow local file import path. You can use it to help an AI assistant
+understand structure before it generates SQL or imports a prepared CSV/XLSX file
+into an existing table.
 
 MySQL supports `explain_query`, but not `explain_query(..., analyze=True)` in
 the current implementation.
@@ -45,16 +46,18 @@ the current implementation.
 | `run_select(connection_id, sql, limit?)` | Yes | Yes | Run read-only queries |
 | `explain_query(connection_id, sql, analyze?)` | Yes | Yes | Inspect query plans |
 | `get_table_sample(connection_id, table_name, schema?, database?, limit?)` | Yes | Yes | Fetch small table samples |
+| `import_table_file(connection_id, table_name, file_path, schema?, database?, sheet_name?)` | Yes | Yes | Import local CSV/XLSX files |
 
 These tools are useful for tasks such as listing namespaces, inspecting table
-definitions, reviewing indexes, sampling records, and analyzing read-only
-queries with `EXPLAIN`. For full request and response details, see
-`docs/api-reference.md` (Chinese).
+definitions, reviewing indexes, sampling records, analyzing read-only queries
+with `EXPLAIN`, and importing prepared local files. For full request and
+response details, see `docs/api-reference.md` (Chinese).
 
 ## How boundaries are constrained
 
 The product boundary is intentionally narrow today. Only PostgreSQL and MySQL
-are available today, and the current tool set is fully read-only.
+are available today. Query tools remain read-only, and the only write path is a
+controlled local CSV/XLSX import into existing tables.
 
 The service keeps those boundaries explicit in a few ways.
 
@@ -68,6 +71,8 @@ The service keeps those boundaries explicit in a few ways.
   database.
 - The server accepts only `SELECT` and `WITH ... SELECT`, rejects comments and
   multi-statement input, and records audit logs for each call.
+- `import_table_file` doesn't accept raw SQL. It inserts only file columns whose
+  headers exactly match existing table columns.
 
 For MySQL, `explain_query(..., analyze=True)` is not available in the current
 implementation.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,8 +4,8 @@
 tool 的适用范围、参数、返回结果和使用示例，用它来编写客户端提示词或核对
 接入测试。
 
-这些 tools 面向 AI 的多数据库发现、结构理解和受控查询流程，并在明确边界内
-保留当前 API 中与 PostgreSQL、MySQL 相关的实际行为差异。
+这些 tools 面向 AI 的多数据库发现、结构理解、受控查询流程和受控文件导入，
+并在明确边界内保留当前 API 中与 PostgreSQL、MySQL 相关的实际行为差异。
 
 ## 响应约定
 
@@ -305,15 +305,59 @@ tool 的适用范围、参数、返回结果和使用示例，用它来编写客
 }
 ```
 
+## `import_table_file(connection_id, table_name, file_path, schema?, database?, sheet_name?)`
+
+这个工具把 MCP server 本机路径上的 CSV 或 XLSX 文件导入到已有表。它是受控
+写入入口，不接受原始 SQL，也不做字段映射、清洗、upsert、merge 或多表导
+入。
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `connection_id` | string | Yes | 连接 ID |
+| `table_name` | string | Yes | 已存在的目标表名 |
+| `file_path` | string | Yes | MCP server 本机可访问的 CSV/XLSX 文件路径 |
+| `schema` | string | PostgreSQL conditional | PostgreSQL schema 名称 |
+| `database` | string | MySQL conditional | MySQL database 名称 |
+| `sheet_name` | string | No | XLSX sheet 名称；不传时读取第一个 sheet |
+
+**Response:**
+
+- `200`: 返回导入目标、文件类型、sheet 名称和 `inserted_row_count`
+- Error: 只支持 `.csv` 和 `.xlsx` 文件
+- Error: 文件表头为空、重复，或包含目标表不存在的字段时会被拒绝
+- Error: 文件没有数据行时会被拒绝
+- Error: XLSX 指定的 `sheet_name` 不存在时会被拒绝
+- Error: 数据库约束失败时会回滚并返回脱敏后的数据库错误
+
+文件表头必须精确匹配目标表字段名，但可以只提供部分字段。未提供的字段交给
+数据库处理，例如自增、默认值、可空字段或约束失败。
+
+**Example:**
+
+```json
+{
+  "connection_id": "crm_mysql_prod_main_rw",
+  "engine": "mysql",
+  "database": "crm",
+  "table_name": "users",
+  "inserted_row_count": 2,
+  "duration_ms": 24,
+  "file_extension": ".xlsx",
+  "sheet_name": "Users"
+}
+```
+
 ## 常见调用建议
 
-如果你是给 AI 写提示词，建议按“先结构，后查询”的顺序调用，能明显减少无
-效 SQL 和错误重试。
+如果你是给 AI 写提示词，建议按“先结构，后查询或导入”的顺序调用，能明显
+减少无效 SQL、错误导入和错误重试。
 
 1. 先调用 `list_connections()` 确认连接 ID。
 2. 再调用 `list_schemas()` 或 `list_databases()` 确认命名空间。
 3. 然后调用 `list_tables()` 和 `describe_table()` 理解结构。
-4. 最后再调用 `run_select()` 或 `explain_query()`。
+4. 最后再调用 `run_select()`、`explain_query()` 或 `import_table_file()`。
 
 ## Next steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "mcp>=1.12.4",
+  "openpyxl>=3.1",
   "PyMySQL>=1.1",
   "psycopg[binary]>=3.2",
   "psycopg-pool>=3.2",

--- a/sql_query_mcp/adapters/mysql.py
+++ b/sql_query_mcp/adapters/mysql.py
@@ -115,6 +115,14 @@ class MySQLAdapter:
             f"{self._quote_identifier(table_name)} LIMIT {int(sentinel_limit)}"
         )
 
+    def build_insert_query(self, database: str, table_name: str, columns: List[str]) -> str:
+        quoted_columns = ", ".join(self._quote_identifier(column) for column in columns)
+        placeholders = ", ".join(["%s"] * len(columns))
+        return (
+            f"INSERT INTO {self._quote_identifier(database)}."
+            f"{self._quote_identifier(table_name)} ({quoted_columns}) VALUES ({placeholders})"
+        )
+
     def build_explain_query(self, sql_text: str, analyze: bool = False) -> str:
         if analyze:
             raise SecurityError("MySQL 首版不支持 analyze=True。")

--- a/sql_query_mcp/adapters/postgres.py
+++ b/sql_query_mcp/adapters/postgres.py
@@ -155,6 +155,16 @@ class PostgresAdapter:
             sql.Literal(sentinel_limit),
         )
 
+    def build_insert_query(self, schema: str, table_name: str, columns: List[str]):
+        if sql is None:
+            raise ConfigurationError("缺少 psycopg 依赖，请先安装项目依赖。")
+        return sql.SQL("INSERT INTO {}.{} ({}) VALUES ({})").format(
+            sql.Identifier(schema),
+            sql.Identifier(table_name),
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns),
+            sql.SQL(", ").join(sql.Placeholder() for _ in columns),
+        )
+
     def build_explain_query(self, sql_text: str, analyze: bool = False) -> str:
         return f"EXPLAIN (FORMAT JSON, ANALYZE {'TRUE' if analyze else 'FALSE'}) {sql_text}"
 

--- a/sql_query_mcp/app.py
+++ b/sql_query_mcp/app.py
@@ -10,6 +10,7 @@ from .audit import AuditLogger
 from .config import load_config
 from .errors import SqlQueryMCPError
 from .executor import QueryExecutor
+from .importer import TableFileImporter
 from .introspection import MetadataService
 from .registry import ConnectionRegistry
 
@@ -20,6 +21,7 @@ def create_app() -> FastMCP:
     audit_logger = AuditLogger(app_config.settings.audit_log_path)
     metadata = MetadataService(registry, app_config.settings, audit_logger)
     executor = QueryExecutor(registry, app_config.settings, audit_logger)
+    importer = TableFileImporter(registry, app_config.settings, audit_logger)
 
     mcp = FastMCP("sql-query-mcp", json_response=True)
 
@@ -85,6 +87,28 @@ def create_app() -> FastMCP:
         """Fetch a small sample from a table for schema discovery."""
 
         return _run_tool(lambda: executor.get_table_sample(connection_id, table_name, schema, database, limit))
+
+    @mcp.tool()
+    def import_table_file(
+        connection_id: str,
+        table_name: str,
+        file_path: str,
+        schema: Optional[str] = None,
+        database: Optional[str] = None,
+        sheet_name: Optional[str] = None,
+    ) -> dict:
+        """Import a local CSV or XLSX file into an existing table."""
+
+        return _run_tool(
+            lambda: importer.import_table_file(
+                connection_id,
+                table_name,
+                file_path,
+                schema,
+                database,
+                sheet_name,
+            )
+        )
 
     return mcp
 

--- a/sql_query_mcp/importer.py
+++ b/sql_query_mcp/importer.py
@@ -1,0 +1,223 @@
+"""Controlled local file imports into existing tables."""
+
+from __future__ import annotations
+
+import csv
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+try:
+    from openpyxl import load_workbook
+except ImportError:  # pragma: no cover - runtime dependency
+    load_workbook = None
+
+from .audit import AuditLogger
+from .config import ServerSettings
+from .errors import QueryExecutionError, sanitize_error_message
+from .namespace import NamespaceSelection, resolve_namespace
+
+
+class TableFileImporter:
+    """Import CSV and XLSX files through a constrained table-only path."""
+
+    def __init__(
+        self,
+        registry: Any,
+        settings: ServerSettings,
+        audit_logger: AuditLogger,
+    ):
+        self._registry = registry
+        self._settings = settings
+        self._audit = audit_logger
+
+    def import_table_file(
+        self,
+        connection_id: str,
+        table_name: str,
+        file_path: str,
+        schema: Optional[str] = None,
+        database: Optional[str] = None,
+        sheet_name: Optional[str] = None,
+    ) -> Dict[str, object]:
+        started = time.perf_counter()
+        config = None
+        namespace = None
+        file_extension = Path(file_path).suffix.lower()
+        selected_sheet_name = None
+        inserted_row_count = 0
+
+        try:
+            config = self._registry.get_connection_config(connection_id)
+            namespace = resolve_namespace(config, schema=schema, database=database)
+            headers, rows, selected_sheet_name = _read_file(Path(file_path), sheet_name)
+            if not rows:
+                raise QueryExecutionError("文件没有可导入的数据行。")
+
+            with self._registry.connection_from_config(config) as (conn, adapter):
+                _apply_statement_timeout(adapter, conn, self._settings.statement_timeout_ms)
+                description = adapter.describe_table(conn, namespace.value, table_name)
+                if not description:
+                    raise QueryExecutionError(
+                        f"未找到表 {namespace.value}.{table_name}，或当前用户没有访问权限"
+                    )
+                table_columns = [item["column_name"] for item in description["columns"]]
+                _validate_headers(headers, table_columns)
+                query = adapter.build_insert_query(namespace.value, table_name, headers)
+                _execute_insert(conn, config.engine, query, rows)
+
+            inserted_row_count = len(rows)
+            duration_ms = _elapsed_ms(started)
+            self._audit.log(
+                tool="import_table_file",
+                connection_id=connection_id,
+                success=True,
+                duration_ms=duration_ms,
+                row_count=inserted_row_count,
+                extra=_build_audit_extra(
+                    config,
+                    namespace,
+                    table_name,
+                    file_extension,
+                    selected_sheet_name,
+                ),
+            )
+            return {
+                "connection_id": connection_id,
+                "engine": config.engine,
+                namespace.field_name: namespace.value,
+                "table_name": table_name,
+                "inserted_row_count": inserted_row_count,
+                "duration_ms": duration_ms,
+                "file_extension": file_extension,
+                "sheet_name": selected_sheet_name,
+            }
+        except Exception as exc:
+            duration_ms = _elapsed_ms(started)
+            sanitized = sanitize_error_message(str(exc))
+            self._audit.log(
+                tool="import_table_file",
+                connection_id=connection_id,
+                success=False,
+                duration_ms=duration_ms,
+                row_count=inserted_row_count,
+                error=sanitized,
+                extra=_build_audit_extra(
+                    config,
+                    namespace,
+                    table_name,
+                    file_extension,
+                    selected_sheet_name,
+                ),
+            )
+            raise QueryExecutionError(sanitized) from exc
+
+
+def _read_file(path: Path, sheet_name: Optional[str]) -> Tuple[List[str], List[Tuple[object, ...]], Optional[str]]:
+    extension = path.suffix.lower()
+    if extension == ".csv":
+        if sheet_name:
+            raise QueryExecutionError("CSV 文件不支持 sheet_name 参数。")
+        return _read_csv(path)
+    if extension == ".xlsx":
+        return _read_xlsx(path, sheet_name)
+    raise QueryExecutionError("仅支持 .csv 和 .xlsx 文件导入。")
+
+
+def _read_csv(path: Path) -> Tuple[List[str], List[Tuple[object, ...]], Optional[str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        try:
+            headers = next(reader)
+        except StopIteration as exc:
+            raise QueryExecutionError("文件表头不能为空。") from exc
+        rows = [_normalize_row(row, len(headers)) for row in reader]
+    return headers, rows, None
+
+
+def _read_xlsx(path: Path, sheet_name: Optional[str]) -> Tuple[List[str], List[Tuple[object, ...]], Optional[str]]:
+    if load_workbook is None:
+        raise QueryExecutionError("缺少 openpyxl 依赖，请先安装项目依赖。")
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    try:
+        if sheet_name:
+            if sheet_name not in workbook.sheetnames:
+                raise QueryExecutionError(f"XLSX 文件中不存在 sheet: {sheet_name}")
+            worksheet = workbook[sheet_name]
+        else:
+            worksheet = workbook.worksheets[0]
+        rows_iter = worksheet.iter_rows(values_only=True)
+        try:
+            header_row = next(rows_iter)
+        except StopIteration as exc:
+            raise QueryExecutionError("文件表头不能为空。") from exc
+        headers = ["" if value is None else str(value) for value in header_row]
+        rows = [_normalize_row(list(row), len(headers)) for row in rows_iter]
+        return headers, rows, worksheet.title
+    finally:
+        workbook.close()
+
+
+def _normalize_row(row: Sequence[object], expected_length: int) -> Tuple[object, ...]:
+    if len(row) != expected_length:
+        raise QueryExecutionError("数据行字段数量必须和表头数量一致。")
+    return tuple(None if value == "" else value for value in row)
+
+
+def _validate_headers(headers: Sequence[str], table_columns: Sequence[str]) -> None:
+    if not headers:
+        raise QueryExecutionError("文件表头不能为空。")
+    empty_headers = [index + 1 for index, header in enumerate(headers) if not header]
+    if empty_headers:
+        raise QueryExecutionError(f"文件表头存在空字段，位置: {empty_headers}")
+    duplicates = sorted({header for header in headers if headers.count(header) > 1})
+    if duplicates:
+        raise QueryExecutionError(f"文件表头存在重复字段: {duplicates}")
+    unknown = sorted(set(headers) - set(table_columns))
+    if unknown:
+        raise QueryExecutionError(f"文件表头包含目标表不存在的字段: {unknown}")
+
+
+def _execute_insert(conn: Any, engine: str, query: object, rows: List[Tuple[object, ...]]) -> None:
+    if engine == "postgres" and hasattr(conn, "transaction"):
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.executemany(query, rows)
+        return
+
+    conn.begin()
+    try:
+        with conn.cursor() as cur:
+            cur.executemany(query, rows)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.perf_counter() - started) * 1000)
+
+
+def _apply_statement_timeout(adapter: Any, conn: Any, timeout_ms: Optional[int]) -> None:
+    if timeout_ms is not None:
+        getattr(adapter, "set_statement_timeout")(conn, timeout_ms)
+
+
+def _build_audit_extra(
+    config: Any,
+    namespace: Optional[NamespaceSelection],
+    table_name: str,
+    file_extension: str,
+    sheet_name: Optional[str],
+) -> Dict[str, object]:
+    extra: Dict[str, object] = {
+        "table_name": table_name,
+        "file_extension": file_extension,
+        "sheet_name": sheet_name,
+    }
+    if config is not None:
+        extra["engine"] = config.engine
+    if namespace is not None:
+        extra[namespace.field_name] = namespace.value
+    return extra

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from sql_query_mcp.app import create_app
+
+
+class AppTestCase(unittest.TestCase):
+    def test_create_app_registers_import_table_file_tool(self) -> None:
+        app = create_app()
+
+        tools = asyncio.run(app.list_tools())
+
+        self.assertIn("import_table_file", {tool.name for tool in tools})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import csv
+import json
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from sql_query_mcp.audit import AuditLogger
+from sql_query_mcp.config import ConnectionConfig, ServerSettings
+from sql_query_mcp.errors import QueryExecutionError
+from sql_query_mcp.importer import TableFileImporter
+
+
+class _CursorStub:
+    def __init__(self, error: Exception | None = None) -> None:
+        self._error = error
+        self.executed_many = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def executemany(self, query, rows) -> None:
+        if self._error is not None:
+            raise self._error
+        self.executed_many.append((query, rows))
+
+
+class _ConnectionStub:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.cursor_stub = _CursorStub(error)
+        self.begin_calls = 0
+        self.commit_calls = 0
+        self.rollback_calls = 0
+
+    def cursor(self) -> _CursorStub:
+        return self.cursor_stub
+
+    def begin(self) -> None:
+        self.begin_calls += 1
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+
+
+class _AdapterStub:
+    def __init__(self) -> None:
+        self.set_statement_timeout_calls = []
+
+    def set_statement_timeout(self, conn: object, timeout_ms: int) -> None:
+        self.set_statement_timeout_calls.append(timeout_ms)
+
+    def describe_table(self, conn: object, namespace: str, table_name: str):
+        return {
+            "columns": [
+                {"column_name": "id"},
+                {"column_name": "name"},
+                {"column_name": "status"},
+            ],
+            "indexes": [],
+        }
+
+    def build_insert_query(self, namespace: str, table_name: str, columns):
+        return f"insert {namespace}.{table_name} ({','.join(columns)})"
+
+
+class _RegistryStub:
+    def __init__(self, config: ConnectionConfig, adapter: object, conn: object) -> None:
+        self._config = config
+        self._adapter = adapter
+        self._conn = conn
+
+    def get_connection_config(self, connection_id: str) -> ConnectionConfig:
+        if connection_id != self._config.connection_id:
+            raise AssertionError(connection_id)
+        return self._config
+
+    @contextmanager
+    def connection_from_config(self, config: ConnectionConfig):
+        if config != self._config:
+            raise AssertionError(config)
+        yield self._conn, self._adapter
+
+
+class TableFileImporterTestCase(unittest.TestCase):
+    def test_import_csv_inserts_header_subset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = _write_csv(
+                Path(temp_dir) / "users.csv",
+                [["name", "status"], ["Alice", "active"], ["Bob", "disabled"]],
+            )
+            conn = _ConnectionStub()
+            log_path = Path(temp_dir) / "audit.jsonl"
+            importer = _build_importer(log_path, conn)
+
+            result = importer.import_table_file(
+                "crm_mysql_prod_main_rw",
+                "users",
+                str(csv_path),
+            )
+
+            records = _read_audit_records(log_path)
+
+        self.assertEqual(2, result["inserted_row_count"])
+        self.assertEqual(".csv", result["file_extension"])
+        self.assertEqual("crm", result["database"])
+        self.assertEqual(1, conn.begin_calls)
+        self.assertEqual(1, conn.commit_calls)
+        self.assertEqual(0, conn.rollback_calls)
+        self.assertEqual(
+            [("insert crm.users (name,status)", [("Alice", "active"), ("Bob", "disabled")])],
+            conn.cursor_stub.executed_many,
+        )
+        self.assertEqual("import_table_file", records[0]["tool"])
+        self.assertEqual(2, records[0]["row_count"])
+        self.assertEqual(".csv", records[0]["extra"]["file_extension"])
+
+    def test_import_csv_rejects_unknown_header_before_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = _write_csv(Path(temp_dir) / "users.csv", [["missing"], ["x"]])
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            with self.assertRaises(QueryExecutionError):
+                importer.import_table_file("crm_mysql_prod_main_rw", "users", str(csv_path))
+
+        self.assertEqual([], conn.cursor_stub.executed_many)
+        self.assertEqual(0, conn.begin_calls)
+
+    def test_import_csv_rejects_duplicate_header_before_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = _write_csv(Path(temp_dir) / "users.csv", [["name", "name"], ["x", "y"]])
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            with self.assertRaises(QueryExecutionError):
+                importer.import_table_file("crm_mysql_prod_main_rw", "users", str(csv_path))
+
+        self.assertEqual([], conn.cursor_stub.executed_many)
+        self.assertEqual(0, conn.begin_calls)
+
+    def test_import_csv_rejects_empty_header_before_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = _write_csv(Path(temp_dir) / "users.csv", [["name", ""], ["x", "y"]])
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            with self.assertRaises(QueryExecutionError):
+                importer.import_table_file("crm_mysql_prod_main_rw", "users", str(csv_path))
+
+        self.assertEqual([], conn.cursor_stub.executed_many)
+        self.assertEqual(0, conn.begin_calls)
+
+    def test_import_file_rejects_unsupported_extension_before_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            txt_path = Path(temp_dir) / "users.txt"
+            txt_path.write_text("name\nAlice\n", encoding="utf-8")
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            with self.assertRaises(QueryExecutionError):
+                importer.import_table_file("crm_mysql_prod_main_rw", "users", str(txt_path))
+
+        self.assertEqual([], conn.cursor_stub.executed_many)
+        self.assertEqual(0, conn.begin_calls)
+
+    def test_import_csv_rejects_file_without_data_rows_before_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = _write_csv(Path(temp_dir) / "users.csv", [["name"]])
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            with self.assertRaises(QueryExecutionError):
+                importer.import_table_file("crm_mysql_prod_main_rw", "users", str(csv_path))
+
+        self.assertEqual([], conn.cursor_stub.executed_many)
+        self.assertEqual(0, conn.begin_calls)
+
+    def test_import_rolls_back_when_database_insert_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = _write_csv(Path(temp_dir) / "users.csv", [["name"], ["Alice"]])
+            conn = _ConnectionStub(RuntimeError("dsn://user:secret@db failed"))
+            log_path = Path(temp_dir) / "audit.jsonl"
+            importer = _build_importer(log_path, conn)
+
+            with self.assertRaises(QueryExecutionError) as caught:
+                importer.import_table_file("crm_mysql_prod_main_rw", "users", str(csv_path))
+
+            records = _read_audit_records(log_path)
+
+        self.assertIn("dsn://user:***@db failed", str(caught.exception))
+        self.assertEqual(1, conn.begin_calls)
+        self.assertEqual(0, conn.commit_calls)
+        self.assertEqual(1, conn.rollback_calls)
+        self.assertFalse(records[0]["success"])
+
+    def test_import_xlsx_uses_first_sheet_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            xlsx_path = _write_xlsx(Path(temp_dir) / "users.xlsx")
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            result = importer.import_table_file(
+                "crm_mysql_prod_main_rw",
+                "users",
+                str(xlsx_path),
+            )
+
+        self.assertEqual("First", result["sheet_name"])
+        self.assertEqual(1, result["inserted_row_count"])
+        self.assertEqual(
+            [("insert crm.users (name)", [("Alice",)])],
+            conn.cursor_stub.executed_many,
+        )
+
+    def test_import_xlsx_uses_named_sheet_when_provided(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            xlsx_path = _write_xlsx(Path(temp_dir) / "users.xlsx")
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            result = importer.import_table_file(
+                "crm_mysql_prod_main_rw",
+                "users",
+                str(xlsx_path),
+                sheet_name="Data",
+            )
+
+        self.assertEqual("Data", result["sheet_name"])
+        self.assertEqual(1, result["inserted_row_count"])
+        self.assertEqual(
+            [("insert crm.users (status)", [("active",)])],
+            conn.cursor_stub.executed_many,
+        )
+
+    def test_import_xlsx_rejects_missing_sheet_before_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            xlsx_path = _write_xlsx(Path(temp_dir) / "users.xlsx")
+            conn = _ConnectionStub()
+            importer = _build_importer(Path(temp_dir) / "audit.jsonl", conn)
+
+            with self.assertRaises(QueryExecutionError):
+                importer.import_table_file(
+                    "crm_mysql_prod_main_rw",
+                    "users",
+                    str(xlsx_path),
+                    sheet_name="Missing",
+                )
+
+        self.assertEqual([], conn.cursor_stub.executed_many)
+        self.assertEqual(0, conn.begin_calls)
+
+
+def _build_importer(log_path: Path, conn: _ConnectionStub) -> TableFileImporter:
+    config = ConnectionConfig(
+        connection_id="crm_mysql_prod_main_rw",
+        engine="mysql",
+        label="CRM MySQL",
+        env="prod",
+        tenant="main",
+        role="rw",
+        dsn_env="MYSQL_CONN",
+        enabled=True,
+        default_database="crm",
+    )
+    return TableFileImporter(
+        registry=_RegistryStub(config, _AdapterStub(), conn),
+        settings=ServerSettings(audit_log_path=log_path),
+        audit_logger=AuditLogger(log_path),
+    )
+
+
+def _write_csv(path: Path, rows: list[list[str]]) -> Path:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerows(rows)
+    return path
+
+
+def _write_xlsx(path: Path) -> Path:
+    workbook = Workbook()
+    first = workbook.active
+    assert first is not None
+    first.title = "First"
+    first.append(["name"])
+    first.append(["Alice"])
+    second = workbook.create_sheet("Data")
+    second.append(["status"])
+    second.append(["active"])
+    workbook.save(path)
+    return path
+
+
+def _read_audit_records(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -73,6 +73,26 @@ class ValidatorTestCase(unittest.TestCase):
         )
         self.assertEqual({"query_block": {"select_id": 1}}, plan)
 
+    def test_postgres_build_insert_query_quotes_identifiers(self) -> None:
+        query = PostgresAdapter().build_insert_query(
+            "public", "orders", ["order", "status"]
+        )
+
+        self.assertEqual(
+            'INSERT INTO "public"."orders" ("order", "status") VALUES (%s, %s)',
+            query.as_string(None),
+        )
+
+    def test_mysql_build_insert_query_quotes_identifiers(self) -> None:
+        query = MySQLAdapter().build_insert_query(
+            "crm", "orders", ["order", "status"]
+        )
+
+        self.assertEqual(
+            "INSERT INTO `crm`.`orders` (`order`, `status`) VALUES (%s, %s)",
+            query,
+        )
+
     def test_mysql_indexes_are_normalized(self) -> None:
         indexes = MySQLAdapter()._normalize_indexes(
             [


### PR DESCRIPTION
## Summary
- Add `import_table_file` for controlled local CSV/XLSX imports into existing PostgreSQL and MySQL tables.
- Validate file headers against target table columns and roll back failed imports.
- Document the new tool and add importer, app wiring, and adapter SQL tests.

## Test Plan
- `.venv/bin/python -m unittest discover -s tests`